### PR TITLE
Readme keepPeriod sample throw an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This module adds a scheduled job that will empty your Alfresco trashcan accordin
 trashcan-cleaner.cron=0 30 2 * * ?
 
 # the period for which trashcan items are kept (in java.time.Duration format)
-# default is 1 month
-trashcan-cleaner.keepPeriod=P1M
+# default is 28 days
+trashcan-cleaner.keepPeriod=P28D
 
 # how many trashcan items to delete per job run
 trashcan-cleaner.deleteBatchCount=1000


### PR DESCRIPTION
Hi,

The readme configuration doesn't work. The sample value is P1M, but Java method **java.time.Duration.parse("P1M")** throw an exception with this value. In alfresco-global.properties the value is P28D.

If someone just read the actual README and want to keep files X months he will put an incorrect value and Alfresco will not start.