### PR TITLE
Fix broken dependency : add repository for spring-social-twitter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <updatePolicy>never</updatePolicy>
             </snapshots>
         </repository>
+	<!-- Required for spring-social-twitter:1.0.0-RC1 -->
+        <repository>
+            <id>spring-milestone</id>
+            <url>https://repo.spring.io/milestone/</url>
+        </repository>
     </repositories>
   <modules>
     <module>alfresco-trashcan-cleaner-amp</module>


### PR DESCRIPTION
Project (tag 1.2.1) doesn't compile anymore as dependency spring-social-twitter:1.0.0-RC1 of alfresco-repository:4.2.b must have been removed from some public repository (Mvn Central or Alfresco).
This dependency is still available in Spring Milestone repository though.

This PR just declares the Spring Milestone repository in the pom.xml to enable the build of this project, in a new 1.2.2 branch.

Another solution could also be to exclude spring-social-twitter from the alfresco-repository dependency, or change its version (using <exclusions>  in the dependency declaration).

As this problem would occur on any project using Alfresco <= 4.2.c, it could be nice if Alfresco could put back spring-social-twitter:1.0.0-RC1 in its public repository.